### PR TITLE
A possible wrong function call in EventEmitterWithHolding-test.js

### DIFF
--- a/src/__tests__/EventEmitterWithHolding-test.js
+++ b/src/__tests__/EventEmitterWithHolding-test.js
@@ -114,7 +114,7 @@ describe('EventEmitterWithHolding', function() {
     emitter.addRetroactiveListener('type1', function() {
       emitter.releaseCurrentEvent();
     });
-    emitter.emit('type1');
+    emitter.emitAndHold('type1');
 
     emitter.addRetroactiveListener('type1', callback);
 


### PR DESCRIPTION
In the last test case of 'EventEmitterWithHolding-test.js', according to the test case description "preventing it (the event) from being held", I think the author expected to go through the following steps:

(step 1) the emitter firstly holds event 'type1';
(step 2) the emitter emits 'type1', therefore, an earlier registered listener is invoked, which does release the current event ('type1') from the holder;
(step 3) the emitter emits held events to a newly-added retroactive listener, but since the held event 'type1' was already gone, so the listener will not be invoked.

Therefore, I think, line#117 should use emitAndHold(), instead of just emit().
