### PR TITLE
[Memory] Break the reference between the subscription and vendor when done

### DIFF
--- a/src/EventSubscription.js
+++ b/src/EventSubscription.js
@@ -5,7 +5,7 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
- * 
+ *
  * @providesModule EventSubscription
  * @typechecks
  */
@@ -30,7 +30,10 @@ class EventSubscription {
    * Removes this subscription from the subscriber that controls it.
    */
   remove() {
-    this.subscriber.removeSubscription(this);
+    if (this.subscriber) {
+      this.subscriber.removeSubscription(this);
+      this.subscriber = null;
+    }
   }
 }
 


### PR DESCRIPTION
It's pretty common to remove a subscription but not null it out ex:
```
cleanup() {
  this._aSubscription.remove();
  // but not "delete this._aSubscription"
}
```

When this happens, there's still a chain of references that looks like object -> subscription -> vendor -> all other subscriptions -> listeners -> the world, so nulling out the reference to the vendor helps reduce leaked memory.