### PR TITLE
[gulp] Make Gulp wait on the Promise returned from `del`

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -15,8 +15,8 @@ var paths = {
   lib: 'lib'
 };
 
-gulp.task('clean', function(cb) {
-  del([paths.lib], cb);
+gulp.task('clean', function() {
+  return del([paths.lib]);
 });
 
 gulp.task('lib', function() {


### PR DESCRIPTION
This fixes the `lib` build step; running `gulp build` now creates `lib` as expected.