### PR TITLE
Update fbjs from v6.x to v7.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "test": "NODE_ENV=test jest"
   },
   "dependencies": {
-    "fbjs": "^0.6.0"
+    "fbjs": "^0.7.1"
   },
   "devDependencies": {
     "babel-core": "^5.8.34",


### PR DESCRIPTION
npm v3 tries to dedupe the dependencies by default, and keeping dependencies up-to-date helps better deduplication.

Though it seems that this repository is not tested on any CIs, I ran `npm test` on my PC and it passed all the tests.

```
$ node --version
v5.5.0

$ npm t

> fbemitter@2.0.1 test /Users/shinnn/github/emitter
> NODE_ENV=test jest

Using Jest CLI v0.8.2, jasmine1
 PASS  src/__tests__/EventSubscriptionVendor-test.js (0.572s)
 PASS  src/__tests__/BaseEventEmitter-test.js (0.686s)
20 tests passed (20 total in 2 test suites, run time 1.457s)
```
