### PR TITLE
Export EmitterSubscription for use in flow-typed apps

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,8 @@
  */
 
 var fbemitter = {
-  EventEmitter: require('./lib/BaseEventEmitter')
+  EventEmitter: require('./lib/BaseEventEmitter'),
+  EmitterSubscription = require('./lib/EmitterSubscription')
 };
 
 module.exports = fbemitter;


### PR DESCRIPTION
EmitterSubscription is part of the BaseEventEmitter API, and should be exported for use/checking in applications.