### PR TITLE
Fix " Invalid shorthand property initializer"

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@
 
 var fbemitter = {
   EventEmitter: require('./lib/BaseEventEmitter'),
-  EmitterSubscription = require('./lib/EmitterSubscription')
+  EmitterSubscription : require('./lib/EmitterSubscription')
 };
 
 module.exports = fbemitter;


### PR DESCRIPTION
 Fix Invalid shorthand property initializer when using babel to compile.