### PR TITLE
Sync from internal, prep v3

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "index.js",
     "lib/"
   ],
-  "main": "index.js",
+  "main": "lib/EventEmitter.js",
   "repository": "facebook/emitter",
   "scripts": {
     "build": "gulp build",

--- a/src/EmitterSubscription.js
+++ b/src/EmitterSubscription.js
@@ -5,19 +5,23 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
- * 
+ *
  * @providesModule EmitterSubscription
- * @typechecks
+ * @flow
  */
 
 'use strict';
 
-var EventSubscription = require('EventSubscription');
+const EventSubscription = require('EventSubscription');
+
+import type EventSubscriptionVendor from 'EventSubscriptionVendor';
 
 /**
  * EmitterSubscription represents a subscription with listener and context data.
  */
 class EmitterSubscription extends EventSubscription {
+  context: ?Object;
+  listener: Function;
 
   /**
    * @param {EventSubscriptionVendor} subscriber - The subscriber that controls
@@ -27,7 +31,11 @@ class EmitterSubscription extends EventSubscription {
    * @param {*} context - Optional context object to use when invoking the
    *   listener
    */
-  constructor(subscriber: EventSubscriptionVendor, listener, context: ?Object) {
+  constructor(
+    subscriber: EventSubscriptionVendor,
+    listener: Function,
+    context: ?Object,
+  ): void {
     super(subscriber);
     this.listener = listener;
     this.context = context;

--- a/src/EventSubscription.js
+++ b/src/EventSubscription.js
@@ -7,29 +7,32 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  *
  * @providesModule EventSubscription
- * @typechecks
+ * @flow
  */
 
 'use strict';
+
+import type EventSubscriptionVendor from 'EventSubscriptionVendor';
 
 /**
  * EventSubscription represents a subscription to a particular event. It can
  * remove its own subscription.
  */
 class EventSubscription {
+  subscriber: EventSubscriptionVendor;
 
   /**
    * @param {EventSubscriptionVendor} subscriber the subscriber that controls
    *   this subscription.
    */
-  constructor(subscriber: EventSubscriptionVendor) {
+  constructor(subscriber: EventSubscriptionVendor): void {
     this.subscriber = subscriber;
   }
 
   /**
    * Removes this subscription from the subscriber that controls it.
    */
-  remove() {
+  remove(): void {
     if (this.subscriber) {
       this.subscriber.removeSubscription(this);
       this.subscriber = null;

--- a/src/EventSubscriptionVendor.js
+++ b/src/EventSubscriptionVendor.js
@@ -5,14 +5,15 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
- * 
+ *
  * @providesModule EventSubscriptionVendor
  * @typechecks
+ * @noflow
  */
 
 'use strict';
 
-var invariant = require('invariant');
+const invariant = require('invariant');
 
 /**
  * EventSubscriptionVendor stores a set of EventSubscriptions that are
@@ -22,7 +23,6 @@ class EventSubscriptionVendor {
 
   constructor() {
     this._subscriptionsForType = {};
-    this._currentSubscription = null;
   }
 
   /**
@@ -39,7 +39,7 @@ class EventSubscriptionVendor {
     if (!this._subscriptionsForType[eventType]) {
       this._subscriptionsForType[eventType] = [];
     }
-    var key = this._subscriptionsForType[eventType].length;
+    const key = this._subscriptionsForType[eventType].length;
     this._subscriptionsForType[eventType].push(subscription);
     subscription.eventType = eventType;
     subscription.key = key;
@@ -67,10 +67,10 @@ class EventSubscriptionVendor {
    * @param {object} subscription
    */
   removeSubscription(subscription: Object) {
-    var eventType = subscription.eventType;
-    var key = subscription.key;
+    const eventType = subscription.eventType;
+    const key = subscription.key;
 
-    var subscriptionsForType = this._subscriptionsForType[eventType];
+    const subscriptionsForType = this._subscriptionsForType[eventType];
     if (subscriptionsForType) {
       delete subscriptionsForType[key];
     }

--- a/src/__tests__/BaseEventEmitter-test.js
+++ b/src/__tests__/BaseEventEmitter-test.js
@@ -5,11 +5,13 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @emails oncall+uiecommd
  */
 
 'use strict';
 
-jest.autoMockOff();
+jest.disableAutomock();
 
 var BaseEventEmitter = require('BaseEventEmitter');
 
@@ -17,7 +19,7 @@ describe('BaseEventEmitter', function() {
   it('notifies listener when told to emit an event which that listener has ' +
      'registered for', function () {
     var emitter = new BaseEventEmitter();
-    var callback = jest.genMockFunction();
+    var callback = jest.fn();
 
     emitter.addListener('type1', callback);
 
@@ -29,7 +31,7 @@ describe('BaseEventEmitter', function() {
   it('allows for the passing of the context when handling events', function() {
     var emitter = new BaseEventEmitter();
     var calledContext;
-    var callback = jest.genMockFunction();
+    var callback = jest.fn();
     callback.mockImplementation(function() {
       calledContext = this;
     });
@@ -46,8 +48,8 @@ describe('BaseEventEmitter', function() {
   it('notifies multiple listeners when told to emit an event which multiple ' +
      'listeners are registered for', function () {
     var emitter = new BaseEventEmitter();
-    var callback1 = jest.genMockFunction();
-    var callback2 = jest.genMockFunction();
+    var callback1 = jest.fn();
+    var callback2 = jest.fn();
 
     emitter.addListener('type1', callback1);
     emitter.addListener('type1', callback2);
@@ -60,7 +62,7 @@ describe('BaseEventEmitter', function() {
 
   it('does not notify events of different types', function() {
     var emitter = new BaseEventEmitter();
-    var callback = jest.genMockFunction();
+    var callback = jest.fn();
 
     emitter.addListener('type1', callback);
 
@@ -71,7 +73,7 @@ describe('BaseEventEmitter', function() {
 
   it('does not notify of events after all listeners are removed', function() {
     var emitter = new BaseEventEmitter();
-    var callback = jest.genMockFunction();
+    var callback = jest.fn();
 
     emitter.addListener('type1', callback);
     emitter.removeAllListeners();
@@ -83,7 +85,7 @@ describe('BaseEventEmitter', function() {
 
   it('does not notify the listener of events after it is removed', function() {
     var emitter = new BaseEventEmitter();
-    var callback = jest.genMockFunction();
+    var callback = jest.fn();
 
     var subscription = emitter.addListener('type1', callback);
     subscription.remove();
@@ -96,8 +98,8 @@ describe('BaseEventEmitter', function() {
   it('invokes only the listeners registered at the time the event was ' +
      'emitted, even if more were added', function() {
     var emitter = new BaseEventEmitter();
-    var callback1 = jest.genMockFunction();
-    var callback2 = jest.genMockFunction();
+    var callback1 = jest.fn();
+    var callback2 = jest.fn();
 
     callback1.mockImplementation(function() {
       emitter.addListener('type1', callback2);
@@ -114,8 +116,8 @@ describe('BaseEventEmitter', function() {
   it('does not invoke listeners registered at the time the event was ' +
      'emitted but later removed during the event loop', function() {
     var emitter = new BaseEventEmitter();
-    var callback1 = jest.genMockFunction();
-    var callback2 = jest.genMockFunction();
+    var callback1 = jest.fn();
+    var callback2 = jest.fn();
 
     callback1.mockImplementation(function() {
       subscription.remove();
@@ -133,7 +135,7 @@ describe('BaseEventEmitter', function() {
   it('does notify other handlers of events after a particular listener has ' +
      'been removed', function() {
     var emitter = new BaseEventEmitter();
-    var callback = jest.genMockFunction();
+    var callback = jest.fn();
 
     var subscription = emitter.addListener('type1', function() {});
     emitter.addListener('type1', callback);
@@ -147,7 +149,7 @@ describe('BaseEventEmitter', function() {
   it('provides a way to remove the current listener when told to do so in ' +
      'the midst of an emitting cycle', function() {
     var emitter = new BaseEventEmitter();
-    var callback = jest.genMockFunction();
+    var callback = jest.fn();
 
     emitter.addListener('type1', callback);
 
@@ -164,7 +166,7 @@ describe('BaseEventEmitter', function() {
 
   it('provides a way to register a listener that is invoked once', function() {
     var emitter = new BaseEventEmitter();
-    var callback = jest.genMockFunction();
+    var callback = jest.fn();
 
     emitter.once('type1', callback);
 
@@ -181,7 +183,9 @@ describe('BaseEventEmitter', function() {
 
     expect(function() {
       emitter.removeCurrentListener();
-    }).toThrow('Not in an emitting cycle; there is no current subscription');
+    }).toThrowError(
+      'Not in an emitting cycle; there is no current subscription'
+    );
   });
 
   it('returns an array of listeners for an event', function() {

--- a/src/__tests__/EventSubscriptionVendor-test.js
+++ b/src/__tests__/EventSubscriptionVendor-test.js
@@ -5,11 +5,13 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @emails oncall+uiecommd
  */
 
 'use strict';
 
-jest.autoMockOff();
+jest.disableAutomock();
 
 var EventSubscriptionVendor = require('EventSubscriptionVendor');
 var EventSubscription = require('EventSubscription');

--- a/src/internal/EventEmitter.js
+++ b/src/internal/EventEmitter.js
@@ -5,11 +5,14 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule EventEmitter
+ * @flow
  */
 
-var fbemitter = {
-  EventEmitter: require('./lib/BaseEventEmitter'),
-  EmitterSubscription : require('./lib/EmitterSubscription')
-};
+const BaseEventEmitter = require('BaseEventEmitter');
 
-module.exports = fbemitter;
+class EventEmitter<TEvent: string> extends BaseEventEmitter<TEvent> {
+}
+
+module.exports = EventEmitter;


### PR DESCRIPTION
cc @josephsavona

Big diff: this changes the top-level require to match internal `require('EventEmitter')`, which is really what we I think we want here.

As for the other type information getting exported previously… not sure it matters. I can followup at some point to apply updates and get the tests running again but for now, meh.

I'm going to merge this and ship it as 3.0.0-alpha.1 for now.