### PR TITLE
Copy `src/**file.js` to `lib/**file.js.flow` for auto-exporting flow annotations

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
   "main": "lib/EventEmitter.js",
   "repository": "facebook/emitter",
   "scripts": {
-    "build": "gulp build",
+    "build": "gulp build && npm run build-dot-flow",
+    "build-dot-flow": "find ./src -name '*.js' -not -path '*/__tests__*' | while read filepath; do cp $filepath `echo $filepath | sed 's/\\/src\\//\\/lib\\//g'`.flow; done",
     "prepublish": "npm run build",
     "test": "NODE_ENV=test jest"
   },


### PR DESCRIPTION
Describe classes via `flow-typed` is too lazy and it may stale with time. 
The moreover types are already in the code. So let export them, like it done in `graphql-js`.
Related: https://github.com/graphql/graphql-js/pull/412