### PR TITLE
Add Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,3 @@
+# Code of Conduct
+
+Facebook has adopted a Code of Conduct that we expect project participants to adhere to. Please [read the full text](https://code.facebook.com/codeofconduct) so that you can understand what actions will and will not be tolerated.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,7 @@
 # Contribute
 
 The main purpose of this repository is to share Facebook's implementation of an emitter. Please see React's [contributing article](https://github.com/facebook/react/blob/master/CONTRIBUTING.md), which generally applies to `fbemitter`, if you are interested in submitting a pull request.
+
+## Code of Conduct
+
+The code of conduct is described in [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,3 @@
+# Contribute
+
+The main purpose of this repository is to share Facebook's implementation of an emitter. Please see React's [contributing article](https://github.com/facebook/react/blob/master/CONTRIBUTING.md), which generally applies to `fbemitter`, if you are interested in submitting a pull request.

--- a/README.md
+++ b/README.md
@@ -122,6 +122,3 @@ class MyEventEmitter extends EventEmitter {
 
 And then you can create instances of `MyEventEmitter` and use it like a standard `EventEmitter`. If you just want to log on each emit and not on each callback called during an emit you can override `emit()` instead of this method.
 
-## Contribute
-
-The main purpose of this repository is to share Facebook's implementation of an emitter. Please see React's [contributing article](https://github.com/facebook/react/blob/master/CONTRIBUTING.md), which generally applies to `fbemitter`, if you are interested in submitting a pull request.


### PR DESCRIPTION
In the past Facebook didn't promote including a Code of Conduct when creating new projects, and many projects skipped this important document. Let's fix it. :)

Even though this project isn't super active, it still makes sense to have a Code of Conduct.

We also split out the 'Contributing' section of the README into a separate `CONTRIBUTING.md` and added a link to the COC there as well.

**why make this change?:**
Facebook Open Source provides a Code of Conduct statement for all
projects to follow, to promote a welcoming and safe open source community.

Exposing the COC via a separate markdown file is a standard being
promoted by Github via the Community Profile in order to meet their Open
Source Guide's recommended community standards.

As you can see, adding this file will improve [the emitter community profile](https://github.com/facebook/emitter/community)
checklist and increase the visibility of our COC.

**test plan:**
Viewing it on my branch -
<img width="1311" alt="screen shot 2017-11-26 at 2 24 53 pm" src="https://user-images.githubusercontent.com/1114467/33244954-d6ae7e94-d2b5-11e7-924b-88bbc6508fcd.png">
<img width="1312" alt="screen shot 2017-11-26 at 2 25 03 pm" src="https://user-images.githubusercontent.com/1114467/33244955-d6c8495a-d2b5-11e7-8edf-3be396874619.png">


**issue:**
internal task t23481323